### PR TITLE
Feature/add unique users counter

### DIFF
--- a/src/LinkyLink/IPAddressUtils.cs
+++ b/src/LinkyLink/IPAddressUtils.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace LinkyLink
+{
+    public static class IPAddressUtils
+    {
+        public static string GetHashedIp(string salt, HttpRequest httpRequest)
+        {
+            IPAddress userIpAddress = httpRequest.HttpContext.Connection?.RemoteIpAddress;
+
+            if (userIpAddress == null)
+                return string.Empty;
+
+            return HashString(userIpAddress.ToString(), salt);
+        }
+
+        private static string HashString(string password, string salt)
+        {
+            string saltInBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(salt));
+            byte[] saltBytes = Convert.FromBase64String(saltInBase64);
+
+            using var rfc2898DeriveBytes = new Rfc2898DeriveBytes(password, saltBytes, 1000);
+            return Convert.ToBase64String(rfc2898DeriveBytes.GetBytes(24));
+        }
+    }
+}

--- a/src/LinkyLink/LinkyLink.csproj
+++ b/src/LinkyLink/LinkyLink.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/LinkyLink/LinkyLink.csproj
+++ b/src/LinkyLink/LinkyLink.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.5" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.14" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.6" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.2" />
-    <PackageReference Include="OpenGraph-Net" Version="3.2.0" />
-    <PackageReference Include="QRCoder" Version="1.3.5" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.10" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.27" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.4" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12" />
+    <PackageReference Include="OpenGraph-Net" Version="3.2.6" />
+    <PackageReference Include="QRCoder" Version="1.4.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/LinkyLink/Models/LinkBundle.cs
+++ b/src/LinkyLink/Models/LinkBundle.cs
@@ -27,5 +27,10 @@ namespace LinkyLink.Models
 
         [JsonProperty("links", NullValueHandling = NullValueHandling.Ignore)]
         public IDictionary<string, string>[] Links { get; set; }
+
+        [JsonProperty("uniqueViews", NullValueHandling = NullValueHandling.Ignore)]
+        public int UniqueViews { get; set; }
+
+        public HashSet<string> HashedIps { get; set; } = new HashSet<string>();
     }
 }

--- a/tests/LinkyLink.Tests/DeleteLinksTests.cs
+++ b/tests/LinkyLink.Tests/DeleteLinksTests.cs
@@ -4,6 +4,7 @@ using LinkyLink.Tests.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Documents;
+using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,11 +19,14 @@ namespace LinkyLink.Tests
         public async Task DeleteLink_Request_Missing_Auth_Credentials_Should_Return_UnAuthorized()
         {
             // Arrange
-            var docs = Fixture.CreateMany<Document>();
+            IEnumerable<Document> docs = Fixture.CreateMany<Document>();
+            ILogger dummyLogger = A.Dummy<ILogger>();
+            Binder dummyBinder = A.Fake<Binder>();
+
             RemoveAuthFromContext();
 
             // Act
-            IActionResult result = await _linkOperations.DeleteLink(this.DefaultRequest, docs, null, "vanityUrl", A.Dummy<ILogger>());
+            IActionResult result = await _linkOperations.DeleteLink(this.DefaultRequest, docs, null, "vanityUrl", dummyBinder, dummyLogger);
             AddAuthToContext();
 
             // Assert
@@ -35,9 +39,10 @@ namespace LinkyLink.Tests
             // Arrange
             IEnumerable<Document> docs = Enumerable.Empty<Document>();
             ILogger fakeLogger = A.Fake<ILogger>();
+            Binder fakeBinder = A.Fake<Binder>();
 
             // Act
-            IActionResult result = await _linkOperations.DeleteLink(this.AuthenticatedRequest, docs, null, "userid", fakeLogger);
+            IActionResult result = await _linkOperations.DeleteLink(this.AuthenticatedRequest, docs, null, "userid", fakeBinder, fakeLogger);
 
             // Assert
             Assert.IsType<NotFoundResult>(result);
@@ -53,9 +58,10 @@ namespace LinkyLink.Tests
             // Arrange
             IEnumerable<Document> docs = Fixture.CreateMany<Document>(1);
             ILogger fakeLogger = A.Fake<ILogger>();
+            Binder fakeBinder = A.Fake<Binder>();
 
             // Act
-            IActionResult result = await _linkOperations.DeleteLink(this.AuthenticatedRequest, docs, null, "userid", fakeLogger);
+            IActionResult result = await _linkOperations.DeleteLink(this.AuthenticatedRequest, docs, null, "userid", fakeBinder, fakeLogger);
 
             // Assert
             Assert.IsType<StatusCodeResult>(result);

--- a/tests/LinkyLink.Tests/LinkyLink.Tests.csproj
+++ b/tests/LinkyLink.Tests/LinkyLink.Tests.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofixture" Version="4.11.0" />
-    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.11.0" />
-    <PackageReference Include="FakeItEasy" Version="5.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Autofixture" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.17.0" />
+    <PackageReference Include="FakeItEasy" Version="7.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Proposal description

Simple way of getting the unique views of a link bundle.
After a request is made to GetLinks endpoint, the new implemention gets the user IP address and in order to safely store the IP address in the new collection property, the IP goes through a RFC 2898 hash function, which uses the `LinkBundle` id as his salt.

If the user IP wasn't added before, the new implementon increments the number of unique views, described by the new `uniqueViews` property.

 ``` diff
{
    "id": "ee5af123-4384-46bb-a837-54eef2158828",
    "userId": "",
    "vanityUrl": "postman-test",
    "description": "",
    "links": [
    ],
+    "uniqueViews": 1,
+    "hashedIps": [
+       "CugZGyXRtR5Th5BOHCg0NkLyIQxqK+cs"
+    ]
}
```